### PR TITLE
Use ncurses' pkg-config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CFLAGS+=-std=c99 -pedantic -Wall -lncurses
+CFLAGS+=-std=c99 -pedantic -Wall
+LDLIBS= $(shell $(PKG_CONFIG) --libs ncurses)
 
 BIN=nbwmon
 


### PR DESCRIPTION
This helps building against ncurses being built with a separate libtinfo, but it's also more appropriate to use LDLIBS here instead of abusing CFLAGS, since this puts CFLAGS/LDFLAGS/LDLIBS/source files in the correct order for newer ld features such as --as-needed to work.
