### PR TITLE
Fix compilation problem with 2.6 kernels

### DIFF
--- a/nbwmon.c
+++ b/nbwmon.c
@@ -1,6 +1,10 @@
 #define _GNU_SOURCE
 
 #ifdef __linux__
+#include <linux/version.h>
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,39)
+#include <sys/socket.h>
+#endif
 #include <linux/if_link.h>
 #elif __OpenBSD__ || __NetBSD__
 #include <sys/socket.h>


### PR DESCRIPTION
I had to apply this fix to be able to compile on 2.6 kernels (namely centos6 and debian6)

Without including `<sys/socket.h>` before `<linux/if_link.h>` compilation fails:

```
In file included from /usr/include/linux/if_link.h:5,
                 from nbwmon.c:4:
/usr/include/linux/netlink.h:34: error: expected specifier-qualifier-list before ‘sa_family_t’
make: *** [nbwmon] Error 1
```
