### PR TITLE
Update error message

### DIFF
--- a/nbwmon.c
+++ b/nbwmon.c
@@ -412,7 +412,7 @@ int main(int argc, char **argv) {
 	} ARGEND;
 
 	if (!detectiface(ifa.ifname))
-		eprintf("Can't find network interface\n");
+		eprintf("Can't find network interface %s\n", ifa.ifname);
 	if (!getcounters(ifa.ifname, &ifa.rx, &ifa.tx))
 		eprintf("Can't read rx and tx bytes for %s\n", ifa.ifname);
 


### PR DESCRIPTION
Tell the user what interface it can't find. Useful for debugging if invoked from a script.

Before:
```
$ nbwmon eth127
Can't find network interface
```
After:
```
$ nbwmon eth127
Can't find network interface eth127
```