### PR TITLE
Print version on stdout, exit 0

### DIFF
--- a/util.c
+++ b/util.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <ncurses.h>
 
+__attribute__ ((noreturn))
 void eprintf(const char *fmt, ...) {
 	va_list ap;
 

--- a/util.h
+++ b/util.h
@@ -3,6 +3,7 @@
 
 #define LEN(x) (sizeof (x) / sizeof *(x))
 
+__attribute__ ((noreturn))
 void eprintf(const char *fmt, ...);
 
 void *emalloc(size_t size);


### PR DESCRIPTION
Fixes GCC fall-through warning.